### PR TITLE
Fix variable link to point to defaults/main.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ see the ComplianceAsCode project at [https://github.com/ComplianceAsCode/content
 
 ## Role Variables
 
-To customize the role to your liking, check out the [list of variables](vars/main.yml).
+To customize the role to your liking, check out the [list of variables](defaults/main.yml).
 
 ## Dependencies
 


### PR DESCRIPTION
`vars/main.yml` is empty as of a8a5d580.

Points information link about customization to `defaults/main.yml` vice `vars/main.yml`.