### PR TITLE
Check the flags for nfs filesystems before the register

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -650,13 +650,13 @@
     regexp: ^#?PRELINKING
     line: PRELINKING=no
   when:
+  - grub2_enable_fips_mode | bool
   - prelink_exists.stat.exists
   - ansible_virtualization_role != "guest" or ansible_virtualization_type != "docker"
   - high_complexity | bool
   - restrict_strategy | bool
   - reboot_required | bool
   - high_severity | bool
-  - grub2_enable_fips_mode | bool
   - medium_disruption | bool
   tags:
   - grub2_enable_fips_mode
@@ -679,13 +679,13 @@
 - name: revert prelinking binaries
   command: /usr/sbin/prelink -ua
   when:
+  - grub2_enable_fips_mode | bool
   - prelink_exists.stat.exists
   - ansible_virtualization_role != "guest" or ansible_virtualization_type != "docker"
   - high_complexity | bool
   - restrict_strategy | bool
   - reboot_required | bool
   - high_severity | bool
-  - grub2_enable_fips_mode | bool
   - medium_disruption | bool
   tags:
   - grub2_enable_fips_mode
@@ -861,13 +861,13 @@
     regexp: fips=.
     replace: fips=1
   when:
+  - grub2_enable_fips_mode | bool
   - fipsargcheck.rc == 0
   - ansible_virtualization_role != "guest" or ansible_virtualization_type != "docker"
   - high_complexity | bool
   - restrict_strategy | bool
   - reboot_required | bool
   - high_severity | bool
-  - grub2_enable_fips_mode | bool
   - medium_disruption | bool
   tags:
   - grub2_enable_fips_mode
@@ -893,13 +893,13 @@
     regexp: (GRUB_CMDLINE_LINUX=.*)"
     replace: \1 fips=1"
   when:
+  - grub2_enable_fips_mode | bool
   - fipsargcheck.rc != 0
   - ansible_virtualization_role != "guest" or ansible_virtualization_type != "docker"
   - high_complexity | bool
   - restrict_strategy | bool
   - reboot_required | bool
   - high_severity | bool
-  - grub2_enable_fips_mode | bool
   - medium_disruption | bool
   tags:
   - grub2_enable_fips_mode
@@ -984,13 +984,13 @@
     regexp: boot=\w*-\w*-\w*-\w*-\w*
     replace: boot={{ bootuuid.stdout }}
   when:
+  - grub2_enable_fips_mode | bool
   - bootargcheck.rc == 0
   - ansible_virtualization_role != "guest" or ansible_virtualization_type != "docker"
   - high_complexity | bool
   - restrict_strategy | bool
   - reboot_required | bool
   - high_severity | bool
-  - grub2_enable_fips_mode | bool
   - medium_disruption | bool
   tags:
   - grub2_enable_fips_mode
@@ -1016,13 +1016,13 @@
     regexp: (GRUB_CMDLINE_LINUX=.*)"
     replace: \1 boot=UUID={{ bootuuid.stdout }}"
   when:
+  - grub2_enable_fips_mode | bool
   - bootargcheck.rc != 0
   - ansible_virtualization_role != "guest" or ansible_virtualization_type != "docker"
   - high_complexity | bool
   - restrict_strategy | bool
   - reboot_required | bool
   - high_severity | bool
-  - grub2_enable_fips_mode | bool
   - medium_disruption | bool
   tags:
   - grub2_enable_fips_mode

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -740,6 +740,7 @@
     name: dracut-fips-aesni
     state: present
   when:
+  - grub2_enable_fips_mode | bool
   - aesni_supported.rc == 0
   - ansible_distribution == 'RedHat'
   - ansible_virtualization_role != "guest" or ansible_virtualization_type != "docker"
@@ -747,7 +748,6 @@
   - restrict_strategy | bool
   - reboot_required | bool
   - high_severity | bool
-  - grub2_enable_fips_mode | bool
   - medium_disruption | bool
   tags:
   - grub2_enable_fips_mode

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17417,8 +17417,8 @@
     state: mounted
     opts: '{{ item.split()[3] }},noexec'
   when:
-  - (points_register.stdout | length > 0)
   - mount_option_noexec_remote_filesystems | bool
+  - (points_register.stdout | length > 0)
   - no_reboot_needed | bool
   - configure_strategy | bool
   - medium_severity | bool
@@ -17466,8 +17466,8 @@
     state: mounted
     opts: '{{ item.split()[3] }},nosuid'
   when:
-  - (points_register.stdout | length > 0)
   - mount_option_nosuid_remote_filesystems | bool
+  - (points_register.stdout | length > 0)
   - no_reboot_needed | bool
   - configure_strategy | bool
   - medium_severity | bool
@@ -17515,11 +17515,11 @@
     state: mounted
     opts: '{{ item.split()[3] }},sec=krb5:krb5i:krb5p'
   when:
+  - mount_option_krb_sec_remote_filesystems | bool
   - (points_register.stdout | length > 0)
   - no_reboot_needed | bool
   - configure_strategy | bool
   - medium_severity | bool
-  - mount_option_krb_sec_remote_filesystems | bool
   - medium_disruption | bool
   - low_complexity | bool
   tags:


### PR DESCRIPTION
If the `mount_option_*` variables are set to false `points_register` is never set, so the playbook fails. This PR moves the test below the check for the flag.