### PR TITLE
Remove follow Option from Replace Module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+---
+name: CI
+'on':
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "30 7 * * 3"
+
+defaults:
+  run:
+    working-directory: 'turingbeing.rhel7_disa_stig'
+
+jobs:
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'turingbeing.rhel7_disa_stig'
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: pip3 install yamllint ansible-lint
+
+      - name: Lint code.
+        run: |
+          yamllint .
+          ansible-lint
+
+  molecule:
+    name: Molecule
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro:
+          - centos7
+
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'turingbeing.rhel7_disa_stig'
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: pip3 install ansible molecule[docker] docker
+
+      - name: Run Molecule tests.
+        run: molecule test
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 language: python
 
 install:
-  - python3 -m install molecule docker
+  - python3 -m install molecule docker testinfra
 
 script:
   - molecule test --scenario-name docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ services:
   - docker
 
 language: python
-python: "2.7"
 
 install:
-  - pip install molecule docker
+  - python3 -m install molecule docker
 
 script:
   - molecule test --scenario-name docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 language: python
 
 install:
-  - python3 -m install molecule docker testinfra
+  - python3 -m pip install molecule docker testinfra
 
 script:
   - molecule test --scenario-name docker

--- a/molecule/docker/molecule.yml
+++ b/molecule/docker/molecule.yml
@@ -3,10 +3,6 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint:
-  name: yamllint
-  options:
-    config-file: .yamllint
 platforms:
   - name: instance
     image: centos:7
@@ -25,7 +21,6 @@ provisioner:
   lint:
     name: ansible-lint
 scenario:
-  name: docker
   test_sequence:
     - lint
     - destroy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -575,7 +575,6 @@
 - name: Do not allow users to reuse recent passwords - system-auth (change)
   replace:
     dest: /etc/pam.d/system-auth
-    follow: true
     regexp: ^(password\s+sufficient\s+pam_unix\.so\s.*remember\s*=\s*)(\S+)(.*)$
     replace: \g<1>{{ var_password_pam_unix_remember }}\g<3>
   tags:
@@ -603,7 +602,6 @@
 - name: Do not allow users to reuse recent passwords - system-auth (add)
   replace:
     dest: /etc/pam.d/system-auth
-    follow: true
     regexp: ^password\s+sufficient\s+pam_unix\.so\s(?!.*remember\s*=\s*).*$
     replace: \g<0> remember={{ var_password_pam_unix_remember }}
   tags:
@@ -1385,7 +1383,6 @@
 - name: Prevent Log In to Accounts With Empty Password - system-auth
   replace:
     dest: /etc/pam.d/system-auth
-    follow: true
     regexp: nullok
   tags:
   - CCE-27286-4
@@ -1414,7 +1411,6 @@
 - name: Prevent Log In to Accounts With Empty Password - password-auth
   replace:
     dest: /etc/pam.d/password-auth
-    follow: true
     regexp: nullok
   tags:
   - CCE-27286-4

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -271,7 +271,6 @@
 - name: Set Password Retry Prompts Permitted Per-Session - system-auth (change)
   replace:
     dest: /etc/pam.d/system-auth
-    follow: true
     regexp: (^.*\spam_pwquality.so\s.*retry\s*=\s*)(\S+)(.*$)
     replace: \g<1>{{ var_password_pam_retry }}\g<3>
   tags:
@@ -298,7 +297,6 @@
 - name: Set Password Retry Prompts Permitted Per-Session - system-auth (add)
   replace:
     dest: /etc/pam.d/system-auth
-    follow: true
     regexp: ^.*\spam_pwquality.so\s(?!.*retry\s*=\s*).*$
     replace: \g<0> retry={{ var_password_pam_retry }}
   tags:


### PR DESCRIPTION
Role contained the follow option in some of the replace module statements.

The follow option in the replace module is deprecated since Ansible 2.5

Have removed to allow the role to execute successfully.