### PR TITLE
The 0.1.59 release includes changes that require Ansible 2.9 or higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ see the ComplianceAsCode project at [https://github.com/ComplianceAsCode/content
 Requirements
 ------------
 
-- Ansible version 2.5 or higher
+- Ansible version 2.9 or higher
 
 Role Variables
 --------------


### PR DESCRIPTION
The tasks/main.yml now includes ansible.builtin syntax that is not valid in Ansible 2.8 and older.

Updating the readme to reflect that new requirement.